### PR TITLE
Fixed Gradle setup

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,25 +1,33 @@
-
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+    
 buildscript {
-    repositories {
-        jcenter()
-        maven { url "https://maven.google.com" }
-        maven { url 'https://jitpack.io' }
-    }
+    // The Android Gradle plugin is only required when opening the android folder stand-alone.
+    // This avoids unnecessary downloads and potential conflicts when the library is included as a
+    // module dependency in an application project.
+    if (project == rootProject) {
+        repositories {
+            google()
+            jcenter()
+            maven { url 'https://www.jitpack.io' }
+        }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        dependencies {
+            classpath("com.android.tools.build:gradle:3.5.3")
+        }
     }
 }
 
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    compileSdkVersion safeExtGet('compileSdkVersion', 28)
+    buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 27
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 28)
         versionCode 1
         versionName "1.0"
     }
@@ -30,13 +38,12 @@ android {
 
 repositories {
     mavenCentral()
-    maven { url "https://maven.google.com" }
-    maven { url 'https://jitpack.io' }
+    google()
+    maven { url 'https://www.jitpack.io' }
 }
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation 'com.github.prscX:AlertView:731bd93650'
     implementation 'com.github.mirrajabi:search-dialog:1.2.2'
-    implementation 'com.android.support:design:27.1.1'
 }


### PR DESCRIPTION
- Load Android Gradle Plugin conditionally.

This wraps the Android Gradle plugin dependency in the buildscripts section of android/build.gradle in a conditional:

```
if (project == rootProject) {
    // ... (dependency here)
}
```

The Android Gradle plugin is only required when opening the project stand-alone, not when it is included as a dependency. By doing this, the project opens correctly in Android Studio, and it can also be consumed as a native module dependency from an application project without affecting the app project (avoiding unnecessary downloads/conflicts/etc).

for more info, you can refer to [this thread](https://github.com/facebook/react-native/pull/25569) and especially [this comment.](https://github.com/facebook/react-native/pull/25569#issuecomment-532504277)

- using the root project gradle setup with a fallback option in case of missing an option

- bump default gradle settings versions to match with RN v61+

- Also, I saw in commit history that this project has been migrated to RN60+ but in the Android Gradle, there was an android support library dependency `'com.android.support:design:27.1.1'`. I didn't see any usage of this dependency in your code so I simply remove it instead of replacing it with Androidx equivalent dependency.